### PR TITLE
Add EEGNet output shape test

### DIFF
--- a/tests/test_eegnet.py
+++ b/tests/test_eegnet.py
@@ -1,0 +1,12 @@
+import torch
+from src.models.eegnet import EEGNetLight
+
+
+def test_forward_output_shape():
+    n_channels = 8
+    n_timepoints = 128
+    n_classes = 3
+    model = EEGNetLight(n_channels=n_channels, n_timepoints=n_timepoints, n_classes=n_classes)
+    x = torch.randn(2, 1, n_channels, n_timepoints)
+    out = model(x)
+    assert out.shape == (2, n_classes)


### PR DESCRIPTION
## Summary
- test EEGNetLight forward pass output shape

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684326315f5883278e97e946267e93f6